### PR TITLE
RavenDB-25086 Add parameter for tagging custom builds with version only

### DIFF
--- a/.github/workflows/docker-build-linux.yml
+++ b/.github/workflows/docker-build-linux.yml
@@ -29,6 +29,11 @@ on:
         required: false
         type: string
         default: ''
+      use_version_tags_only:
+        description: 'Use version tags only'
+        required: false
+        type: boolean
+        default: false
 
 env:
   DRY_RUN: ${{ inputs.dry_run }}
@@ -97,12 +102,22 @@ jobs:
               ;;
           esac
           wget -P "../artifacts" "$downloadURL"
+
+          extraArgs=""
+          if [ "${{ inputs.use_version_tags_only }}" = "true" ]; then
+            extraArgs="-UseVersionTagsOnly"
+          fi
           
-          pwsh build-ubuntu.ps1 -Repo ${{ inputs.docker_repo }} -Arch ${{ matrix.arch }}
+          pwsh build-ubuntu.ps1 -Repo ${{ inputs.docker_repo }} -Arch ${{ matrix.arch }} $extraArgs
         working-directory: docker
 
       - name: Publish package
         run: |
-          pwsh publish-ubuntu.ps1 -Repo ${{ inputs.docker_repo }} -Arch ${{ matrix.arch }}
+          extraArgs=""
+          if [ "${{ inputs.use_version_tags_only }}" = "true" ]; then
+            extraArgs="-UseVersionTagsOnly"
+          fi
+
+          pwsh publish-ubuntu.ps1 -Repo ${{ inputs.docker_repo }} -Arch ${{ matrix.arch }} $extraArgs
           docker logout
         working-directory: docker

--- a/.github/workflows/docker-build-windows.yml
+++ b/.github/workflows/docker-build-windows.yml
@@ -29,6 +29,11 @@ on:
           required: false
           type: string
           default: ''
+      use_version_tags_only:
+        description: 'Use version tags only'
+        required: false
+        type: boolean
+        default: false
 
 env:
   DRY_RUN: ${{ inputs.dry_run }}
@@ -79,12 +84,22 @@ jobs:
       - name: Build image
         shell: pwsh
         run: |
-          & .\build-nanoserver.ps1 -Repo ${{ inputs.docker_repo }} -WinVer ${{ matrix.data.winVer }}
+          $cmd = ".\build-nanoserver.ps1 -Repo `"${{ inputs.docker_repo }}`" -WinVer `"${{ matrix.data.winVer }}`""
+          if ("${{ inputs.use_version_tags_only }}" -eq "true") {
+            $cmd += " -UseVersionTagsOnly"
+          }
+          Write-Host "Running: $cmd"
+          Invoke-Expression $cmd
         working-directory: docker
 
       - name: Publish package
         shell: pwsh
         run: |
-          & .\publish-nanoserver.ps1 -Repo ${{ inputs.docker_repo }} -WinVer ${{ matrix.data.winVer }}
+          $cmd = ".\publish-nanoserver.ps1 -Repo `"${{ inputs.docker_repo }}`" -WinVer `"${{ matrix.data.winVer }}`""
+          if ("${{ inputs.use_version_tags_only }}" -eq "true") {
+            $cmd += " -UseVersionTagsOnly"
+          }
+          Write-Host "Running: $cmd"
+          Invoke-Expression $cmd
           docker logout
         working-directory: docker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,7 @@ jobs:
       dry_run: ${{ inputs.dry_run }}
       docker_repo: ${{ needs.commonVars.outputs.docker_repo }}
       raven_major_minor: ${{ needs.commonVars.outputs.raven_major_minor }}
+      use_version_tags_only: ${{ needs.commonVars.outputs.is_stable == 'false' && needs.commonVars.outputs.is_nightly == 'false' }}
     secrets: inherit
 
   docker-windows:
@@ -101,11 +102,12 @@ jobs:
       dry_run: ${{ inputs.dry_run }}
       docker_repo: ${{ needs.commonVars.outputs.docker_repo }}
       raven_major_minor: ${{ needs.commonVars.outputs.raven_major_minor }}
+      use_version_tags_only: ${{ needs.commonVars.outputs.is_stable == 'false' && needs.commonVars.outputs.is_nightly == 'false' }}
     secrets: inherit
 
   docker-multiarch:
     needs: [commonVars, docker-linux, docker-windows]
-    if: always() && inputs.deb_only == false
+    if: always() && inputs.deb_only == false && (needs.commonVars.outputs.is_stable == 'true' || needs.commonVars.outputs.is_nightly == 'true')
     uses: ./.github/workflows/docker-create-multiarch.yml
     with:
       version: ${{ inputs.version }}


### PR DESCRIPTION
Param is set automatically - when not stable and not nightly build.
sample action - https://github.com/hiddenshadow21/ravendb-docker-builds/actions/runs/18303920903