### PR TITLE
RavenDB-26659: add workflow to build and push the Quill Docker image

### DIFF
--- a/.github/workflows/docker-build-ai-appliance.yml
+++ b/.github/workflows/docker-build-ai-appliance.yml
@@ -1,0 +1,128 @@
+name: Build Quil Docker image
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Quil version'
+        required: true
+        type: string
+      docker_user:
+        description: 'DockerHub username'
+        required: false
+        type: string
+        default: ravendb
+      docker_repo:
+        description: 'DockerHub repository'
+        required: false
+        type: string
+        default: ravendb/quil
+      github_repository:
+        description: 'Github repository'
+        required: false
+        type: string
+        default: ravendb/ravendb
+      github_ref:
+        description: 'Git ref of github_repository to build from'
+        required: false
+        type: string
+        default: feature/ai-appliance
+      platforms:
+        description: 'Comma-separated buildx platforms'
+        required: false
+        type: string
+        default: linux/amd64
+      dry_run:
+        description: 'Dry run - skip docker login/push'
+        required: false
+        type: string
+        default: ''
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Quil version'
+        required: true
+        type: string
+      docker_user:
+        description: 'DockerHub username'
+        required: false
+        type: string
+        default: ravendb
+      docker_repo:
+        description: 'DockerHub repository'
+        required: false
+        type: string
+        default: ravendb/quil
+      github_repository:
+        description: 'Github repository'
+        required: false
+        type: string
+        default: ravendb/ravendb
+      github_ref:
+        description: 'Git ref of github_repository to build from'
+        required: false
+        type: string
+        default: feature/ai-appliance
+      platforms:
+        description: 'Comma-separated buildx platforms'
+        required: false
+        type: string
+        default: linux/amd64
+      dry_run:
+        description: 'Dry run - skip docker login/push'
+        required: false
+        type: string
+        default: ''
+
+env:
+  DRY_RUN: ${{ inputs.dry_run }}
+
+jobs:
+  build:
+    name: Build & push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ inputs.github_repository }}@${{ inputs.github_ref }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.github_repository }}
+          ref: ${{ inputs.github_ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute tags
+        id: tags
+        shell: bash
+        run: |
+          V="${{ inputs.version }}"
+          MINOR="${V%.*}"
+          REPO="${{ inputs.docker_repo }}"
+          echo "pinned=$REPO:$V"           >> "$GITHUB_OUTPUT"
+          echo "minor=$REPO:$MINOR-latest" >> "$GITHUB_OUTPUT"
+          echo "latest=$REPO:latest"       >> "$GITHUB_OUTPUT"
+
+      - name: Login to Docker Hub
+        if: ${{ inputs.dry_run == '' }}
+        run: docker login -u ${{ inputs.docker_user }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Build & push
+        shell: bash
+        run: |
+          PUSH_FLAG="--push"
+          if [ -n "$DRY_RUN" ]; then
+            PUSH_FLAG="--dry-run"
+          fi
+          ./docker/ai-appliance/scripts/build.sh \
+            --tag ${{ steps.tags.outputs.pinned }} \
+            --tag ${{ steps.tags.outputs.minor }} \
+            --tag ${{ steps.tags.outputs.latest }} \
+            --platforms ${{ inputs.platforms }} \
+            $PUSH_FLAG
+
+      - name: Docker logout
+        if: ${{ always() && inputs.dry_run == '' }}
+        run: docker logout || true

--- a/.github/workflows/docker-build-quill.yml
+++ b/.github/workflows/docker-build-quill.yml
@@ -31,6 +31,14 @@ on:
         required: false
         type: boolean
         default: true
+      mode:
+        description: 'Build mode: source (compile Raven.Server + Raven.Studio from repo) | nightly (pull binaries from ravendb-nightly image)'
+        required: false
+        type: choice
+        default: source
+        options:
+          - source
+          - nightly
       dry_run:
         description: 'Dry run - build locally, skip login/push'
         required: false
@@ -77,11 +85,13 @@ jobs:
             ./docker/quill/scripts/build.sh \
               --tag "${{ inputs.docker_repo }}:${{ inputs.version }}-${{ matrix.arch }}" \
               --platforms "${{ matrix.platform }}" \
+              --mode "${{ inputs.mode }}" \
               --dry-run
           else
             ./docker/quill/scripts/build.sh \
               --tag "${{ inputs.docker_repo }}:${{ inputs.version }}-${{ matrix.arch }}" \
               --platforms "${{ matrix.platform }}" \
+              --mode "${{ inputs.mode }}" \
               --push
           fi
 

--- a/.github/workflows/docker-build-quill.yml
+++ b/.github/workflows/docker-build-quill.yml
@@ -52,9 +52,6 @@ jobs:
           - arch: arm64v8
             platform: linux/arm64
             runs-on: ubuntu-24.04-arm
-          - arch: arm32v7
-            platform: linux/arm/v7
-            runs-on: ubuntu-latest # QEMU
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -63,14 +60,6 @@ jobs:
         with:
           repository: ${{ inputs.github_repository }}
           ref: ${{ inputs.github_ref }}
-
-      - name: Set up QEMU
-        if: matrix.arch == 'arm32v7'
-        uses: docker/setup-qemu-action@v3
-
-      - name: Reset QEMU
-        if: matrix.arch == 'arm32v7'
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes
 
       - name: Set up buildx
         uses: docker/setup-buildx-action@v3
@@ -121,17 +110,16 @@ jobs:
           VERSION="${{ inputs.version }}"
           MINOR=$(echo "$VERSION" | cut -d. -f1,2)
 
-          # The three per-arch tags each build job just pushed.
+          # The two per-arch tags each build job just pushed.
           AMD64="$REPO:$VERSION-amd64"
           ARM64="$REPO:$VERSION-arm64v8"
-          ARM32="$REPO:$VERSION-arm32v7"
 
           # Stitch them into a manifest published under the pinned version tag.
-          docker buildx imagetools create --tag "$REPO:$VERSION" "$AMD64" "$ARM64" "$ARM32"
+          docker buildx imagetools create --tag "$REPO:$VERSION" "$AMD64" "$ARM64"
 
           if [ "${{ inputs.push_latest_tags }}" = "true" ]; then
-            docker buildx imagetools create --tag "$REPO:$MINOR-latest" "$AMD64" "$ARM64" "$ARM32"
-            docker buildx imagetools create --tag "$REPO:latest"        "$AMD64" "$ARM64" "$ARM32"
+            docker buildx imagetools create --tag "$REPO:$MINOR-latest" "$AMD64" "$ARM64"
+            docker buildx imagetools create --tag "$REPO:latest"        "$AMD64" "$ARM64"
           fi
 
       - name: Docker logout

--- a/.github/workflows/docker-build-quill.yml
+++ b/.github/workflows/docker-build-quill.yml
@@ -1,47 +1,5 @@
 name: Build Quill Docker image
 on:
-  workflow_call:
-    inputs:
-      version:
-        description: 'Quill version'
-        required: true
-        type: string
-      docker_user:
-        description: 'DockerHub username'
-        required: false
-        type: string
-        default: ravendb
-      docker_repo:
-        description: 'DockerHub repository'
-        required: false
-        type: string
-        default: ravendb/quill
-      github_repository:
-        description: 'Github repository'
-        required: false
-        type: string
-        default: ravendb/ravendb
-      github_ref:
-        description: 'Git ref of github_repository to build from'
-        required: false
-        type: string
-        default: feature/ai-appliance
-      platforms:
-        description: 'Comma-separated buildx platforms'
-        required: false
-        type: string
-        default: linux/amd64
-      push_latest_tags:
-        description: 'Also push :latest and :<minor>-latest floating tags'
-        required: false
-        type: boolean
-        default: true
-      dry_run:
-        description: 'Dry run - build locally, skip login/push'
-        required: false
-        type: string
-        default: ''
-
   workflow_dispatch:
     inputs:
       version:
@@ -68,11 +26,6 @@ on:
         required: false
         type: string
         default: feature/ai-appliance
-      platforms:
-        description: 'Comma-separated buildx platforms'
-        required: false
-        type: string
-        default: linux/amd64
       push_latest_tags:
         description: 'Also push :latest and :<minor>-latest floating tags'
         required: false
@@ -89,8 +42,21 @@ env:
 
 jobs:
   build:
-    name: Build & push
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runs-on: ubuntu-latest
+          - arch: arm64v8
+            platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+          - arch: arm32v7
+            platform: linux/arm/v7
+            runs-on: ubuntu-latest # QEMU
+      fail-fast: false
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout ${{ inputs.github_repository }}@${{ inputs.github_ref }}
         uses: actions/checkout@v4
@@ -99,23 +65,15 @@ jobs:
           ref: ${{ inputs.github_ref }}
 
       - name: Set up QEMU
+        if: matrix.arch == 'arm32v7'
         uses: docker/setup-qemu-action@v3
+
+      - name: Reset QEMU
+        if: matrix.arch == 'arm32v7'
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes
 
       - name: Set up buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Compute tags
-        id: tags
-        shell: bash
-        run: |
-          V="${{ inputs.version }}"
-          MINOR="${V%.*}"
-          REPO="${{ inputs.docker_repo }}"
-          echo "pinned=$REPO:$V" >> "$GITHUB_OUTPUT"
-          if [ "${{ inputs.push_latest_tags }}" = "true" ]; then
-            echo "minor=$REPO:$MINOR-latest" >> "$GITHUB_OUTPUT"
-            echo "latest=$REPO:latest"       >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Login to Docker Hub
         if: ${{ inputs.dry_run == '' }}
@@ -123,24 +81,59 @@ jobs:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
         run: docker login -u ${{ inputs.docker_user }} -p "$DOCKER_HUB_PASSWORD"
 
-      - name: Build & push
+      - name: Build & push per-arch image
         shell: bash
         run: |
-          extraTags=""
-          if [ -n "${{ steps.tags.outputs.minor }}" ]; then
-            extraTags="--tag ${{ steps.tags.outputs.minor }} --tag ${{ steps.tags.outputs.latest }}"
+          if [ -n "$DRY_RUN" ]; then
+            ./docker/quill/scripts/build.sh \
+              --tag "${{ inputs.docker_repo }}:${{ inputs.version }}-${{ matrix.arch }}" \
+              --platforms "${{ matrix.platform }}" \
+              --dry-run
+          else
+            ./docker/quill/scripts/build.sh \
+              --tag "${{ inputs.docker_repo }}:${{ inputs.version }}-${{ matrix.arch }}" \
+              --platforms "${{ matrix.platform }}" \
+              --push
           fi
-
-          # Dry-run: build locally (no --push) so we still validate the image builds.
-          pushFlag="--push"
-          [ -n "$DRY_RUN" ] && pushFlag=""
-
-          ./docker/quill/scripts/build.sh \
-            --tag ${{ steps.tags.outputs.pinned }} \
-            $extraTags \
-            --platforms ${{ inputs.platforms }} \
-            $pushFlag
 
       - name: Docker logout
         if: ${{ always() && inputs.dry_run == '' }}
+        run: docker logout || true
+
+  multiarch:
+    name: Create multiarch manifest
+    needs: build
+    if: ${{ inputs.dry_run == '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        env:
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        run: docker login -u ${{ inputs.docker_user }} -p "$DOCKER_HUB_PASSWORD"
+
+      - name: Create multiarch manifest
+        shell: bash
+        run: |
+          REPO="${{ inputs.docker_repo }}"
+          VERSION="${{ inputs.version }}"
+          MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+
+          # The three per-arch tags each build job just pushed.
+          AMD64="$REPO:$VERSION-amd64"
+          ARM64="$REPO:$VERSION-arm64v8"
+          ARM32="$REPO:$VERSION-arm32v7"
+
+          # Stitch them into a manifest published under the pinned version tag.
+          docker buildx imagetools create --tag "$REPO:$VERSION" "$AMD64" "$ARM64" "$ARM32"
+
+          if [ "${{ inputs.push_latest_tags }}" = "true" ]; then
+            docker buildx imagetools create --tag "$REPO:$MINOR-latest" "$AMD64" "$ARM64" "$ARM32"
+            docker buildx imagetools create --tag "$REPO:latest"        "$AMD64" "$ARM64" "$ARM32"
+          fi
+
+      - name: Docker logout
+        if: always()
         run: docker logout || true

--- a/.github/workflows/docker-build-quill.yml
+++ b/.github/workflows/docker-build-quill.yml
@@ -31,8 +31,13 @@ on:
         required: false
         type: string
         default: linux/amd64
+      push_latest_tags:
+        description: 'Also push :latest and :<minor>-latest floating tags'
+        required: false
+        type: boolean
+        default: true
       dry_run:
-        description: 'Dry run - skip docker login/push'
+        description: 'Dry run - build locally, skip login/push'
         required: false
         type: string
         default: ''
@@ -68,8 +73,13 @@ on:
         required: false
         type: string
         default: linux/amd64
+      push_latest_tags:
+        description: 'Also push :latest and :<minor>-latest floating tags'
+        required: false
+        type: boolean
+        default: true
       dry_run:
-        description: 'Dry run - skip docker login/push'
+        description: 'Dry run - build locally, skip login/push'
         required: false
         type: string
         default: ''
@@ -101,27 +111,35 @@ jobs:
           V="${{ inputs.version }}"
           MINOR="${V%.*}"
           REPO="${{ inputs.docker_repo }}"
-          echo "pinned=$REPO:$V"           >> "$GITHUB_OUTPUT"
-          echo "minor=$REPO:$MINOR-latest" >> "$GITHUB_OUTPUT"
-          echo "latest=$REPO:latest"       >> "$GITHUB_OUTPUT"
+          echo "pinned=$REPO:$V" >> "$GITHUB_OUTPUT"
+          if [ "${{ inputs.push_latest_tags }}" = "true" ]; then
+            echo "minor=$REPO:$MINOR-latest" >> "$GITHUB_OUTPUT"
+            echo "latest=$REPO:latest"       >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Login to Docker Hub
         if: ${{ inputs.dry_run == '' }}
-        run: docker login -u ${{ inputs.docker_user }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
+        env:
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        run: docker login -u ${{ inputs.docker_user }} -p "$DOCKER_HUB_PASSWORD"
 
       - name: Build & push
         shell: bash
         run: |
-          PUSH_FLAG="--push"
-          if [ -n "$DRY_RUN" ]; then
-            PUSH_FLAG="--dry-run"
+          extraTags=""
+          if [ -n "${{ steps.tags.outputs.minor }}" ]; then
+            extraTags="--tag ${{ steps.tags.outputs.minor }} --tag ${{ steps.tags.outputs.latest }}"
           fi
+
+          # Dry-run: build locally (no --push) so we still validate the image builds.
+          pushFlag="--push"
+          [ -n "$DRY_RUN" ] && pushFlag=""
+
           ./docker/quill/scripts/build.sh \
             --tag ${{ steps.tags.outputs.pinned }} \
-            --tag ${{ steps.tags.outputs.minor }} \
-            --tag ${{ steps.tags.outputs.latest }} \
+            $extraTags \
             --platforms ${{ inputs.platforms }} \
-            $PUSH_FLAG
+            $pushFlag
 
       - name: Docker logout
         if: ${{ always() && inputs.dry_run == '' }}

--- a/.github/workflows/docker-build-quill.yml
+++ b/.github/workflows/docker-build-quill.yml
@@ -1,9 +1,9 @@
-name: Build Quil Docker image
+name: Build Quill Docker image
 on:
   workflow_call:
     inputs:
       version:
-        description: 'Quil version'
+        description: 'Quill version'
         required: true
         type: string
       docker_user:
@@ -15,7 +15,7 @@ on:
         description: 'DockerHub repository'
         required: false
         type: string
-        default: ravendb/quil
+        default: ravendb/quill
       github_repository:
         description: 'Github repository'
         required: false
@@ -40,7 +40,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Quil version'
+        description: 'Quill version'
         required: true
         type: string
       docker_user:
@@ -52,7 +52,7 @@ on:
         description: 'DockerHub repository'
         required: false
         type: string
-        default: ravendb/quil
+        default: ravendb/quill
       github_repository:
         description: 'Github repository'
         required: false
@@ -116,7 +116,7 @@ jobs:
           if [ -n "$DRY_RUN" ]; then
             PUSH_FLAG="--dry-run"
           fi
-          ./docker/ai-appliance/scripts/build.sh \
+          ./docker/quill/scripts/build.sh \
             --tag ${{ steps.tags.outputs.pinned }} \
             --tag ${{ steps.tags.outputs.minor }} \
             --tag ${{ steps.tags.outputs.latest }} \


### PR DESCRIPTION
## Summary

https://issues.hibernatingrhinos.com/issue/RavenDB-26659/Quill-Docker-Image

---

Publish workflow for the Quill (RavenDB AI Appliance) Docker image.

- Reusable workflow (`workflow_call` + `workflow_dispatch`).
- Builds from source in `ravendb/ravendb` (via the Dockerfile added there in https://github.com/ravendb/ravendb/pull/23079 ), pushes to `ravendb/quill` on Docker Hub.
- Multi-arch capable (`linux/amd64` default, `linux/amd64,linux/arm64` via input).
- Pushes three tags per release: `<version>`, `<minor>-latest`, `latest`.
- Honors `DRY_RUN` - skips login/push, prints the docker command instead.


## Test plan executed on my fork

All 4 cases plus a manual post-push smoke ran green on [`TheGoldenPlatypus/ravendb-docker-builds` ](https://github.com/TheGoldenPlatypus/ravendb-docker-builds)

### 1. [Dry-run (no creds used, no push) ](https://github.com/TheGoldenPlatypus/ravendb-docker-builds/actions/runs/28519936895/job/84541186699): 

params: 
```
version           = 0.1.0-test1
docker_user       = (default: ravendb — no login step ran)
docker_repo       = thegoldenplatypus/quill
github_repository = TheGoldenPlatypus/ravendb
github_ref        = RavenDB-26659
platforms         = linux/amd64
dry_run           = 1

```
```
DRY RUN: docker buildx build --platform linux/amd64 -f docker/Quill/Dockerfile -t thegoldenplatypus/quill:0.1.0-test1 -t thegoldenplatypus/quill:0.1-latest -t thegoldenplatypus/quill:latest --load .
```

### 2. [Real push, `linux/amd64`](https://github.com/TheGoldenPlatypus/ravendb-docker-builds/actions/runs/28520098184/job/84541725893)

params: 
```
version           = 0.1.0-test2
docker_user       = thegoldenplatypus
docker_repo       = thegoldenplatypus/quill
github_repository = TheGoldenPlatypus/ravendb
github_ref        = RavenDB-26659
platforms         = linux/amd64
dry_run           = (empty)
```

Three tags landed on `TheGoldenPlatypus/quill`: `0.1.0-test2`, `0.1-latest`, `latest`.

https://hub.docker.com/repository/docker/thegoldenplatypus/quill/general


### 3. [Multi-arch push (`linux/amd64,linux/arm64`)](https://github.com/TheGoldenPlatypus/ravendb-docker-builds/actions/runs/28521407857/job/84546274217)

params: 
```
version           = 0.1.0-test3
docker_user       = thegoldenplatypus
docker_repo       = thegoldenplatypus/quill
github_repository = TheGoldenPlatypus/ravendb
github_ref        = RavenDB-26659
platforms         = linux/amd64,linux/arm64
dry_run           = (empty)

```

Manifest list contains both platforms.

```
omer@Omer-Ratsaby-NLP:~$ docker buildx imagetools inspect thegoldenplatypus/quill:0.1.0-test3
Name:      docker.io/thegoldenplatypus/quill:0.1.0-test3
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:d6ffbb8ea92f0d7fad27f665916a5069debe821a758fd4ad6e0aa32a82264286

Manifests:
  Name:      docker.io/thegoldenplatypus/quill:0.1.0-test3@sha256:4dcd1e...
  Platform:  linux/amd64

  Name:      docker.io/thegoldenplatypus/quill:0.1.0-test3@sha256:8dbd8a...
  Platform:  linux/arm64
```


### [4. Floating tag movement](https://github.com/TheGoldenPlatypus/ravendb-docker-builds/actions/runs/28522361080/job/84549652574)

params: 
```
version           = 0.2.0-test4
docker_user       = thegoldenplatypus
docker_repo       = thegoldenplatypus/quill
github_repository = TheGoldenPlatypus/ravendb
github_ref        = RavenDB-26659
platforms         = linux/amd64
dry_run           = (empty)
```
Pushed `0.2.0-test4`. `latest` moved off `0.1.x`; `0.1-latest` stayed frozen.

https://hub.docker.com/repository/docker/thegoldenplatypus/quill/general


### 5 . Post-push smoke - pull and run the published image

Fresh `docker pull` + `docker run` of `thegoldenplatypus/quill:latest`. Container started, s6 supervised all three services, `/healthz` returned the expected 503 (`needs-activation`) because `test` is not a real license token.

```
omer@Omer-Ratsaby-NLP:~$ docker pull thegoldenplatypus/quill:latest
latest: Pulling from thegoldenplatypus/quill
Digest: sha256:d6ffbb8ea92f0d7fad27f665916a5069debe821a758fd4ad6e0aa32a82264286

omer@Omer-Ratsaby-NLP:~$ docker run -d --name quill-final -p 5000:5000 \
  -e QUILL_API_KEY=test -e QUILL_LICENSE_KEY=test \
  thegoldenplatypus/quill:latest
09b603514258faaf0e90c0c837398cf1caae82c7e453ffcb39d17e45785b3c56

omer@Omer-Ratsaby-NLP:~$ docker logs 09b603
s6-rc: info: service 01-ravendb successfully started
s6-rc: info: service 03-proxy successfully started
s6-rc: info: service s6rc-oneshot-runner successfully started
s6-rc: info: service 02-web successfully started
s6-rc: info: service fix-attrs successfully started
s6-rc: info: service legacy-cont-init successfully started
s6-rc: info: service legacy-services successfully started

       _____                       _____  ____
      |  __ \                     |  __ \|  _ \
      | |__) |__ ___   _____ _ __ | |  | | |_) |
      |  _  // _` \ \ / / _ \ '_ \| |  | |  _ <
      | | \ \ (_| |\ V /  __/ | | | |__| | |_) |
      |_|  \_\__,_| \_/ \___|_| |_|_____/|____/


      Safe by default, optimized for efficiency

 Build 72, Version 7.2, SemVer 7.2.5-custom-72, Commit a377982
 PID 41, 64 bits, 8 Cores, Phys Mem 23.471 GBytes, Arch: X64
 Source Code (git repo): https://github.com/ravendb/ravendb
 Built with love by RavenDB Ltd. and awesome contributors!
+---------------------------------------------------------------+
warn: Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository[60]
      Storing keys in a directory '/root/.aspnet/DataProtection-Keys' that may not be persisted outside of the container. Protected data will be unavailable when container is destroyed. For more information go to https://aka.ms/aspnet/dataprotectionwarning
info: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[62]
      User profile is available. Using '/root/.aspnet/DataProtection-Keys' as key repository; keys will not be encrypted at rest.
info: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[58]
      Creating key {18b5fa81-d1df-487d-99bf-317d9a6dcfb4} with creation date 2026-07-02 07:02:59Z, activation date 2026-07-02 07:02:59Z, and expiration date 2026-09-30 07:02:59Z.
info: System.Net.Http.HttpClient.ILicenseClient.LogicalHandler[100]
      Start processing HTTP request GET https://api.ravendb.net/api/v1/quill/licenses/test
info: System.Net.Http.HttpClient.ILicenseClient.ClientHandler[100]
      Sending HTTP request GET https://api.ravendb.net/api/v1/quill/licenses/test
info: Raven.AiAppliance.Hosting.RavenReadinessService[0]
      Waiting 00:00:15 for RavenDB to start before probing readiness...
warn: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[35]
      No XML encryptor configured. Key {18b5fa81-d1df-487d-99bf-317d9a6dcfb4} may be persisted to storage in unencrypted form.
info: Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository[39]
      Writing data to file '/root/.aspnet/DataProtection-Keys/key-18b5fa81-d1df-487d-99bf-317d9a6dcfb4.xml'.
warn: Microsoft.AspNetCore.Hosting.Diagnostics[15]
      Overriding HTTP_PORTS '8080' and HTTPS_PORTS ''. Binding to values defined by URLS instead 'http://0.0.0.0:5000'.
info: Microsoft.Hosting.Lifetime[14]
      Now listening on: http://0.0.0.0:5000
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
info: Microsoft.Hosting.Lifetime[0]
      Content root path: /app/web
info: System.Net.Http.HttpClient.ILicenseClient.ClientHandler[101]
      Received HTTP response headers after 879.813ms - 404
info: System.Net.Http.HttpClient.ILicenseClient.LogicalHandler[101]
      End processing HTTP request after 886.8941ms - 404
fail: Raven.AiAppliance.Hosting.ApplianceActivationService[0]
      Activation: failed to retrieve the setup package.
      Raven.AiAppliance.AiHelper.LicenseRetrievalException: license API returned 404 Not Found retrieving the setup package.
         at Raven.AiAppliance.AiHelper.LicenseHttpClient.DownloadSetupPackageToAsync(String token, Stream destination, CancellationToken ct) in /src/src/Raven.AiAppliance/AiHelper/LicenseHttpClient.cs:line 35
         at Raven.AiAppliance.Hosting.ApplianceActivationService.ExecuteAsync(CancellationToken stoppingToken) in /src/src/Raven.AiAppliance/Hosting/ApplianceActivationService.cs:line 62
         at Raven.AiAppliance.Hosting.ApplianceActivationService.ExecuteAsync(CancellationToken stoppingToken) in /src/src/Raven.AiAppliance/Hosting/ApplianceActivationService.cs:line 62
Using GC in server concurrent mode retaining memory from the OS. DATAS disabled.
Server available on: http://09b603514258:8080
Tcp listening on 0.0.0.0:42947
Server started, listening to requests...
TIP: type 'help' to list the available commands.
ravendb> End of standard input detected, switching to server mode...
Running non-interactive.
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 GET http://127.0.0.1:5000/healthz - - -
info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
```